### PR TITLE
Fix: Remove duplicated line causing SyntaxError in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -508,7 +508,6 @@ function work() {
 
   // Output
   outputElement.innerHTML = `Promille: ${promille.toFixed(
-  outputElement.innerHTML = `Promille: ${promille.toFixed(
     2
   )}‰ ${emoji} ${promille > 0.5 ? '<br/>⛔🚗🚫' : ''}`
   outputElement.style.filter = `blur(${Math.min(


### PR DESCRIPTION
A duplicated line `outputElement.innerHTML = `Promille: ${promille.toFixed(` was present in the `work()` function, leading to a JavaScript SyntaxError. This commit removes the redundant line to resolve the error.

The surrounding logic for displaying the promille output and applying conditional CSS effects remains unchanged.