### PR TITLE
feat: Enhance BAC calculation precision and add user options

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,31 @@
         <i>arrow_drop_down</i>
         <span class="helper">Geschlecht</span>
       </div>
+      <div class="s12">
+        <label>
+          <input type="checkbox" id="inputFood" />
+          <span>Drinking with food (slower absorption)?</span>
+        </label>
+      </div>
+      <div class="field suffix border s12 m6"> <!-- Adjust s12 m6 as needed for layout -->
+        <select id="inputBodyType">
+          <option value="average" selected>Average</option>
+          <option value="slim">Slim</option>
+          <option value="aboveaverage">Above Average</option>
+        </select>
+        <i>arrow_drop_down</i>
+        <span class="helper">Body Type</span>
+      </div>
+      <div class="field suffix border s12 m6">
+        <select id="inputDecayRate">
+          <option value="0.08">Slow (0.08‰/h)</option>
+          <option value="0.10" selected>Average (0.10‰/h)</option>
+          <option value="0.12">Fast (0.12‰/h)</option>
+          <option value="0.15">Very Fast (0.15‰/h)</option>
+        </select>
+        <i>arrow_drop_down</i>
+        <span class="helper">Alcohol Decay Rate</span>
+      </div>
     </div>
 
     <table class="border">


### PR DESCRIPTION
This commit introduces several improvements to the Blood Alcohol Content (BAC) calculation to provide a more precise and personalized estimation:

1.  **Realistic Absorption Model:**
    - Implemented a time-to-peak BAC model. Alcohol from each drink is now absorbed gradually (default 45 mins empty stomach, 75 mins with food) before decay starts, replacing the previous instant absorption model.

2.  **Food Intake Option:**
    - Added a checkbox for you to indicate if you are drinking with food.
    - If food is present, the absorption period is extended, simulating a slower rise in BAC.

3.  **Refined Widmark 'r' Factor:**
    - You can now select your body type (Slim, Average, Above Average).
    - This, along with gender, determines a more specific Widmark 'r' (alcohol distribution ratio) factor, improving formula accuracy.
      - Male: Slim (0.73), Average (0.68), Above (0.60)
      - Female: Slim (0.60), Average (0.55), Above (0.50) - Diverse: Averages of male/female values for each category.

4.  **Adjustable Decay Rate:**
    - You can now select your estimated alcohol decay rate from predefined options (Slow: 0.08‰/h, Average: 0.10‰/h, Fast: 0.12‰/h, Very Fast: 0.15‰/h).
    - This replaces the previous fixed decay rate.

All new user preferences (food intake, body type, decay rate) are stored in localStorage and reloaded on subsequent visits. I confirmed these changes function as expected and integrate well with existing features.