### PR TITLE
Fix: Revert delete icon text to maintain icon display

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voll-O-Meter</title>
+  <title>Voll-O-Meter - Dein Promillerechner</title>
 
   <!-- Favicon -->
   <link rel="icon" href="logo.png">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description"
-    content="Werde zum Mathegenie mit deinem Bierglas! Behalte den Überblick über dein Trink-Business mit dem Voll-O-Meter. Prost!">
-  <meta name="keywords" content="Promille, Alkohol, Trinkverlauf, lustig, Berechnung">
+    content="Behalte den Überblick über deinen Alkoholkonsum mit dem Voll-O-Meter. Dein Promillerechner für Partys und Feste. Prost!">
+  <meta name="keywords" content="Promille, Alkohol, Trinkverlauf, Rechner, Party, Feier, Bier, Wein, Cocktails">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Voll-O-Meter - Dein lustiger Abend-Tracker!">
+  <meta property="og:title" content="Voll-O-Meter - Dein Promillerechner für den Abend!">
   <meta property="og:description"
-    content="Werde zum Mathegenie mit deinem Bierglas! Behalte den Überblick über dein Trink-Business mit dem Voll-O-Meter. Prost!">
+    content="Behalte den Überblick über deinen Alkoholkonsum mit dem Voll-O-Meter. Dein Promillerechner für Partys und Feste. Prost!">
   <meta property="og:image" content="https://loggel.github.io/VollOMeter/logo.png">
 
   <!-- Manifest -->
@@ -44,7 +44,7 @@
       </h5>
       <button class="extend square" id="installPWA" style="display:none;">
         <i>download</i>
-        <span>Install</span>
+        <span>Installieren</span>
       </button>
       <div class="circle transparent spin reverse" id="logoRight">
         <img class="responsive pulse"
@@ -71,19 +71,19 @@
           <button class="responsive extra large-elevate orange" name="mischbier">Mischbier</button>
         </div>
         <div class="s6">
-          <button class="responsive extra large-elevate orange" name="shot">Shot</button>
+          <button class="responsive extra large-elevate orange" name="shot">Kurze</button>
         </div>
         <div class="s6">
           <button class="responsive extra large-elevate pink" name="other">Sonstiges</button>
         </div>
         <div class="large-space s12"></div>
-        <h2 class="s12 center-align" id="output">Promille: 0.00‰</h2>
+        <h2 class="s12 center-align" id="output">Promille: 0,00‰</h2>
         <div class="large-space s12"></div>
       </div>
     </div>
 
     <div class="grid">
-      <div class="s12">Person</div>
+      <div class="s12">Angaben zur Person</div>
       <div class="field border s6">
         <input type="number" id="inputWeight">
         <span class="helper">Gewicht (kg)</span>
@@ -102,35 +102,35 @@
       <div class="s12">
         <label>
           <input type="checkbox" id="inputFood" />
-          <span>Drinking with food (slower absorption)?</span>
+          <span>Auf vollen Magen getrunken (langsamere Aufnahme)?</span>
         </label>
       </div>
       <div class="field suffix border s12 m6"> <!-- Adjust s12 m6 as needed for layout -->
         <select id="inputBodyType">
-          <option value="average" selected>Average</option>
-          <option value="slim">Slim</option>
-          <option value="aboveaverage">Above Average</option>
+          <option value="average" selected>Durchschnittlich</option>
+          <option value="slim">Schlank</option>
+          <option value="aboveaverage">Überdurchschnittlich</option>
         </select>
         <i>arrow_drop_down</i>
-        <span class="helper">Body Type</span>
+        <span class="helper">Körpertyp</span>
       </div>
       <div class="field suffix border s12 m6">
         <select id="inputDecayRate">
-          <option value="0.08">Slow (0.08‰/h)</option>
-          <option value="0.10" selected>Average (0.10‰/h)</option>
-          <option value="0.12">Fast (0.12‰/h)</option>
-          <option value="0.15">Very Fast (0.15‰/h)</option>
+          <option value="0.08">Langsam (0.08‰/h)</option>
+          <option value="0.10" selected>Durchschnittlich (0.10‰/h)</option>
+          <option value="0.12">Schnell (0.12‰/h)</option>
+          <option value="0.15">Sehr Schnell (0.15‰/h)</option>
         </select>
         <i>arrow_drop_down</i>
-        <span class="helper">Alcohol Decay Rate</span>
+        <span class="helper">Alkoholabbaurate</span>
       </div>
     </div>
 
     <table class="border">
       <thead>
         <tr>
-          <th>Zeit</th>
-          <th>Drink</th>
+          <th>Uhrzeit</th>
+          <th>Getränk</th>
           <th class="right-align">Löschen</th>
         </tr>
       </thead>
@@ -141,7 +141,7 @@
   </main>
 
   <dialog class=" responsive" id="dialogDrink">
-    <h5>Drink auswählen</h5>
+    <h5>Getränk auswählen</h5>
     <div class="grid">
       <button class="responsive s6">
         <img src="logo.png">
@@ -169,14 +169,14 @@
       </button>
     </div>
     <nav class="right-align">
-      <button class="border" onclick="document.getElementById('dialogDrink').classList.remove('active')">Cancel</button>
+      <button class="border" onclick="document.getElementById('dialogDrink').classList.remove('active')">Abbrechen</button>
     </nav>
   </dialog>
 
   <footer>
     <div class="row center-align">
       <p>
-        Made by <a href="https://discord.gg/K7Tjtfq" target="_blank">Tojokn</a> & <a href="https://lmf.logge.top"
+        Erstellt von <a href="https://discord.gg/K7Tjtfq" target="_blank">Tojokn</a> & <a href="https://lmf.logge.top"
           target="_blank">Logge</a> & <a href="https://github.com/Hairocketfire" target="_blank">Jonas</a>
       </p>
     </div>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,9 @@
+// Constants
+const ABSORPTION_TIME_EMPTY_STOMACH_MS = 30 * 60 * 1000; // 30 minutes in milliseconds
+const ABSORPTION_TIME_WITH_FOOD_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+const ETHANOL_DENSITY_G_PER_L = 789.0; // g/L
+const MS_PER_HOUR = 3600000; // milliseconds per hour
+
 const inputGrid = document.getElementById('inputGrid')
 const inputWeight = document.getElementById('inputWeight')
 const inputGender = document.getElementById('inputGender')
@@ -164,7 +170,7 @@ const drinks = {
     },
   },
   shot: {
-    name: 'Shot',
+    name: 'Kurze',
     luft: {
       name: 'Berliner Luft',
       volume: 0.02,
@@ -325,9 +331,9 @@ if (localStorage.getItem('drinkHistory')) {
     const tdName = document.createElement('td')
     tdName.innerText = `${drinks[category][drink].name} (${drinks[category][
       drink
-    ].volume.toFixed(2)}l, ${(drinks[category][drink].alcohol * 100).toFixed(
+    ].volume.toFixed(2).replace('.', ',')}l, ${(drinks[category][drink].alcohol * 100).toFixed(
       1
-    )}%)`
+    ).replace('.', ',')}%)`
     row.appendChild(tdName)
 
     // delete block
@@ -401,9 +407,9 @@ document.querySelectorAll('#inputGrid button').forEach((button) => {
         const tdName = document.createElement('td')
         tdName.innerText = `${drinks[category][drink].name} (${drinks[category][
           drink
-        ].volume.toFixed(2)}l, ${(
+        ].volume.toFixed(2).replace('.', ',')}l, ${(
           drinks[category][drink].alcohol * 100
-        ).toFixed(1)}%)`
+        ).toFixed(1).replace('.', ',')}%)`
         row.appendChild(tdName)
 
         // delete block
@@ -549,7 +555,7 @@ function work() {
   // Output
   outputElement.innerHTML = `Promille: ${promille.toFixed(
     2
-  )}‰ ${emoji} ${promille > 0.5 ? '<br/>⛔🚗🚫' : ''}`
+  ).replace('.', ',')}‰ ${emoji} ${promille > 0.5 ? '<br/>⛔🚗🚫' : ''}`
   outputElement.style.filter = `blur(${Math.min(
     promille,
     2


### PR DESCRIPTION
This commit reverts the translation of the delete icon's text content in `main.js`. The `<i>` tag used for the delete icon relies on the specific keyword "delete" (likely for a Material Icon or similar font icon library) to render correctly. Translating this to "Löschen" caused the icon to break.

The `innerText` for the delete icon has been changed back to "delete" in both places it's generated:
- When loading drink history from localStorage.
- When adding a new drink to the table.