### PR TITLE
Add light mode functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
         <img src="logo.png" class="title-logo" alt="Logo">
         <h1>Voll-O-Meter</h1>
       </div>
+      <button class="install-btn" id="themeToggle" aria-label="Theme umschalten" title="Theme umschalten">
+        <span class="install-icon">🌓</span>
+        <span id="themeToggleText">Light</span>
+      </button>
       <button class="install-btn" id="installPWA" style="display:none;">
         <span class="install-icon">⬇️</span>
         <span>Installieren</span>

--- a/main.css
+++ b/main.css
@@ -46,6 +46,22 @@
   --border-radius-lg: 16px;
 }
 
+/* ===== LIGHT THEME ===== */
+:root[data-theme="light"] {
+  /* Neutral Colors */
+  --bg-primary: #f7f7f8;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f0f2f5;
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-muted: #6b7280;
+  --border-color: #e5e7eb;
+  --shadow-color: rgba(0, 0, 0, 0.08);
+
+  /* Effects */
+  --gradient-dark: linear-gradient(135deg, #ffffff, #f7f7f8);
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: var(--bg-primary);
@@ -53,6 +69,57 @@ body {
   line-height: 1.6;
   min-height: 100vh;
   overflow-x: hidden;
+}
+
+/* Component tweaks for light theme */
+:root[data-theme="light"] .form-section {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+:root[data-theme="light"] .form-input,
+:root[data-theme="light"] .form-select {
+  background: #ffffff;
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+:root[data-theme="light"] .form-input:focus,
+:root[data-theme="light"] .form-select:focus {
+  background-color: #ffffff;
+}
+
+:root[data-theme="light"] .form-label {
+  background: var(--bg-primary);
+}
+
+:root[data-theme="light"] .drink-btn {
+  color: var(--text-primary);
+}
+
+:root[data-theme="light"] .output-section h2 {
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+}
+
+:root[data-theme="light"] .drinks-table th {
+  color: #ffffff;
+}
+
+:root[data-theme="light"] .modal {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme="light"] .modal-content {
+  background: var(--gradient-dark);
+}
+
+:root[data-theme="light"] .drink-glass {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: var(--text-muted);
+}
+
+:root[data-theme="light"] .footer {
+  border-top-color: var(--border-color);
 }
 
 /* ===== LAYOUT ===== */

--- a/main.js
+++ b/main.js
@@ -1,3 +1,47 @@
+// Theme handling
+;(function initTheme() {
+  const root = document.documentElement
+  const saved = localStorage.getItem('theme')
+  const systemPrefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+  const initialTheme = saved || (systemPrefersLight ? 'light' : 'dark')
+  if (initialTheme === 'light') {
+    root.setAttribute('data-theme', 'light')
+  } else {
+    root.removeAttribute('data-theme')
+  }
+  const btn = document.getElementById('themeToggle')
+  const label = document.getElementById('themeToggleText')
+  const setLabel = () => {
+    const isLight = root.getAttribute('data-theme') === 'light'
+    if (label) label.textContent = isLight ? 'Dark' : 'Light'
+  }
+  setLabel()
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const isLight = root.getAttribute('data-theme') === 'light'
+      if (isLight) {
+        root.removeAttribute('data-theme')
+        localStorage.setItem('theme', 'dark')
+      } else {
+        root.setAttribute('data-theme', 'light')
+        localStorage.setItem('theme', 'light')
+      }
+      setLabel()
+    })
+  }
+  // Update if system preference changes and user has no explicit choice
+  if (!saved && window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+      if (e.matches) {
+        root.setAttribute('data-theme', 'light')
+      } else {
+        root.removeAttribute('data-theme')
+      }
+      setLabel()
+    })
+  }
+})()
+
 // Constants
 const ABSORPTION_TIME_EMPTY_STOMACH_MS = 30 * 60 * 1000 // 30 minutes in milliseconds
 const ABSORPTION_TIME_WITH_FOOD_MS = 2 * 60 * 60 * 1000 // 2 hours in milliseconds


### PR DESCRIPTION
Add a light mode theme with a toggle button and persistence to allow users to switch between dark and light interfaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-698ae9b1-314f-41f4-9185-56de9ab16d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-698ae9b1-314f-41f4-9185-56de9ab16d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

